### PR TITLE
[fix] カレンダーをクリックしてモーダルウィンドウに表示される各投稿の日時を修正

### DIFF
--- a/app/javascript/packs/calendar.js
+++ b/app/javascript/packs/calendar.js
@@ -29,7 +29,6 @@ document.addEventListener("turbolinks:load", function () {
           li.className = "list-group-item d-flex justify-content-between align-items-center";
 
           var startTime = new Date(event.start_time);
-          startTime.setUTCHours(startTime.getUTCHours() - 9);
 
           var japanHours = startTime.getHours();
           var ampm = (japanHours >= 12) ? '午後' : '午前';


### PR DESCRIPTION
モーダルウィンドウに表示される各投稿の日時を日本時間に修正